### PR TITLE
Update to hunter v0.20.64 and rename Sugar -> sugar

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,8 +6,8 @@ cmake_minimum_required(VERSION 3.0)
 ### Hunter snapshot that will be used ###
 include("cmake/HunterGate.cmake")
 HunterGate(
-    URL "https://github.com/ruslo/hunter/archive/v0.19.102.tar.gz"
-    SHA1 "49a8333d7efc24c531aed97159fe58a68374185f"
+    URL "https://github.com/ruslo/hunter/archive/v0.20.64.tar.gz"
+    SHA1 "7b830dfda7a094b2af15f44b24ebd2489404d880"
 )
 
 project(Leathers VERSION 0.2.0)
@@ -22,16 +22,16 @@ option(
 
 ### Download dependencies ###
 hunter_add_package(Boost)
-hunter_add_package(Sugar)
+hunter_add_package(sugar)
 
 ### Find dependencies ###
 find_package(Boost REQUIRED)
+find_package(sugar CONFIG REQUIRED)
 
 ### - ###
-include("${SUGAR_ROOT}/cmake/Sugar")
+sugar_include(Source)
 include(sugar_generate_warning_flags)
 include(sugar_groups_generate)
-include(sugar_include)
 
 ### Target sources. Init variables: ###
 #    LEATHERS_SOURCES

--- a/cmake/HunterGate.cmake
+++ b/cmake/HunterGate.cmake
@@ -54,24 +54,25 @@ include(CMakeParseArguments) # cmake_parse_arguments
 
 option(HUNTER_STATUS_PRINT "Print working status" ON)
 option(HUNTER_STATUS_DEBUG "Print a lot info" OFF)
+option(HUNTER_TLS_VERIFY "Enable/disable TLS certificate checking on downloads" ON)
 
 set(HUNTER_WIKI "https://github.com/ruslo/hunter/wiki")
 
 function(hunter_gate_status_print)
-  foreach(print_message ${ARGV})
-    if(HUNTER_STATUS_PRINT OR HUNTER_STATUS_DEBUG)
+  if(HUNTER_STATUS_PRINT OR HUNTER_STATUS_DEBUG)
+    foreach(print_message ${ARGV})
       message(STATUS "[hunter] ${print_message}")
-    endif()
-  endforeach()
+    endforeach()
+  endif()
 endfunction()
 
 function(hunter_gate_status_debug)
-  foreach(print_message ${ARGV})
-    if(HUNTER_STATUS_DEBUG)
+  if(HUNTER_STATUS_DEBUG)
+    foreach(print_message ${ARGV})
       string(TIMESTAMP timestamp)
       message(STATUS "[hunter *** DEBUG *** ${timestamp}] ${print_message}")
-    endif()
-  endforeach()
+    endforeach()
+  endif()
 endfunction()
 
 function(hunter_gate_wiki wiki_page)
@@ -275,6 +276,8 @@ function(hunter_gate_download dir)
       "    SHA1=${HUNTER_GATE_SHA1}\n"
       "    DOWNLOAD_DIR\n"
       "    \"${dir}\"\n"
+      "    TLS_VERIFY\n"
+      "    ${HUNTER_TLS_VERIFY}\n"
       "    SOURCE_DIR\n"
       "    \"${dir}/Unpacked\"\n"
       "    CONFIGURE_COMMAND\n"


### PR DESCRIPTION

Sugar was apparently renamed to sugar in hunter, but the version of Leathers in hunter still depends on Sugar. This breaks `hunter_add_package(Leathers)`

This pr attempts to fix the dependency after which a new version of Leathers can be released and added to hunter. 
